### PR TITLE
Remove White Border around iframe and swap to Hostname lookup

### DIFF
--- a/portainer/iframe.js
+++ b/portainer/iframe.js
@@ -1,14 +1,12 @@
 // iframe.js
 window.onload = function () {
     var iframe = document.getElementById("my-iframe");
+    // Get the hostname of the current (parent) window
+    var parentHostname = window.location.hostname; // Get IP Address or Hostname
 
-    cockpit.spawn(["hostname", "-I"]).stream(function (data) {
-        var hostIP = data.trim().split(' ')[0]; // Extract the first IP address
-        var url = "https://" + hostIP + ":9443/";
+    var portainerUrl = "https://" + parentHostname + ":9443/";
 
-
-        iframe.src = url;
-    });
+    iframe.src = portainerUrl;
 };
 
 function openSource() {

--- a/portainer/style.css
+++ b/portainer/style.css
@@ -1,10 +1,19 @@
-iframe {
-    width: 99%;
-    position: absolute;
-    height: 99%;
-    border: none;
-    /* Optional: Remove iframe border */
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
     overflow: hidden;
+}
+
+iframe {
+    width: 100%;
+    position: absolute;
+    height: 100%;
+    border: none;
+    overflow: hidden;
+    top: 0;
+    top: 0;
 }
 
 /* Style the button with an icon */


### PR DESCRIPTION
use CSS on the html and body elements to remove the white border
alter the iframe javascript to use the hostname so it supports installations that work via a local dns server